### PR TITLE
Removes xml::ruby dependency.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,5 @@ maintainer_email 'martin@mbs3.org'
 license          'apache2'
 description      'Provides a resource and provider for incremental editing of XML files'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.3'
-
-depends 'xml'
+chef_version     '>= 12.12'
+version          '3.1.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,5 +15,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-include_recipe 'xml::ruby'


### PR DESCRIPTION
- Per https://github.com/chef-boneyard/xml the xml cookbook is deprecated as `nokogiri` is now included in `chef`.
- See https://github.com/chef/chef/pull/4435 for details on the above point.
- Constrain this cookbook to Chef versions 12.12 and above as `nokogiri` support should exist there.